### PR TITLE
Adds Codable conformance

### DIFF
--- a/Sources/SemVer/Version.swift
+++ b/Sources/SemVer/Version.swift
@@ -305,3 +305,5 @@ extension Version.FormattingOptions {
     @inlinable
     public static var dropTrailingZeros: Version.FormattingOptions { [.dropMinorIfZero, .dropPatchIfZero] }
 }
+
+extension Version: Codable { }

--- a/Tests/SemVerTests/VersionTests.swift
+++ b/Tests/SemVerTests/VersionTests.swift
@@ -259,6 +259,18 @@ final class VersionTests: XCTestCase {
         XCTAssertNil(Version("🥴"))
     }
 
+    func testCodable() throws {
+        guard let version = Version("1.2.3") else {
+            XCTFail("String literal init failed")
+            return
+        }
+        XCTAssertNoThrow(try JSONEncoder().encode(version))
+        let encoded = try JSONEncoder().encode(version)
+        XCTAssertNotNil(encoded)
+        let decoded = try JSONDecoder().decode(Version.self, from: encoded)
+        XCTAssertEqual(decoded, version)
+    }
+
     /*
     func testStringLiteralConversion() {
         XCTAssertEqual("1.2.3", Version(major: 1, minor: 2, patch: 3))


### PR DESCRIPTION
Hi @sersoft-gmbh! I’ve added explicit `Codable` conformance to `Version`.  I’m happy to take comments for improvements on this PR.