### PR TITLE
Swift 6 support to avoid conflicts in packages that depend on higher version of swift syntax

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -1,10 +1,10 @@
 {
-  "originHash" : "c15b8eb31cada33eb1f713b456024a131cbd11ae660f6dc2a505e2ea2a5da402",
+  "originHash" : "30cfa7890c6b53d6f4291c6924a4fecd22347431cd18a98bf872167a0c5023c1",
   "pins" : [
     {
       "identity" : "swift-docc-plugin",
       "kind" : "remoteSourceControl",
-      "location" : "https://github.com/apple/swift-docc-plugin",
+      "location" : "https://github.com/swiftlang/swift-docc-plugin",
       "state" : {
         "revision" : "2eb22993b3dfd0c0d32729b357c8dabb6cd44680",
         "version" : "1.4.2"
@@ -22,10 +22,10 @@
     {
       "identity" : "swift-syntax",
       "kind" : "remoteSourceControl",
-      "location" : "https://github.com/apple/swift-syntax",
+      "location" : "https://github.com/swiftlang/swift-syntax",
       "state" : {
-        "revision" : "2bc86522d115234d1f588efe2bcb4ce4be8f8b82",
-        "version" : "510.0.3"
+        "revision" : "515f79b522918f83483068d99c68daeb5116342d",
+        "version" : "600.0.0-prerelease-2024-09-04"
       }
     }
   ],

--- a/Package.swift
+++ b/Package.swift
@@ -14,7 +14,6 @@ let swiftSettings: Array<SwiftSetting> = [
     .enableExperimentalFeature("AccessLevelOnImport"),
     .enableExperimentalFeature("StrictConcurrency"),
     .enableExperimentalFeature("GlobalConcurrency"),
-//    .enableExperimentalFeature("VariadicGenerics"),
 ]
 
 let package = Package(
@@ -36,8 +35,8 @@ let package = Package(
             targets: ["SemVerMacros"]),
     ],
     dependencies: [
-        .package(url: "https://github.com/apple/swift-docc-plugin", from: "1.0.0"),
-        .package(url: "https://github.com/apple/swift-syntax", from: "510.0.1"),
+        .package(url: "https://github.com/swiftlang/swift-docc-plugin", from: "1.0.0"),
+        .package(url: "https://github.com/swiftlang/swift-syntax",  from: "510.0.1"),
     ],
     targets: [
         // Targets are the basic building blocks of a package. A target can define a module or a test suite.

--- a/Package@swift-6.0.swift
+++ b/Package@swift-6.0.swift
@@ -1,16 +1,13 @@
-// swift-tools-version:5.9
+// swift-tools-version:6.0
 // The swift-tools-version declares the minimum version of Swift required to build this package.
 
 import PackageDescription
 import CompilerPluginSupport
 
 let swiftSettings: Array<SwiftSetting> = [
-    .enableUpcomingFeature("ConciseMagicFile"),
     .enableUpcomingFeature("ExistentialAny"),
-    .enableUpcomingFeature("BareSlashRegexLiterals"),
-    .enableUpcomingFeature("DisableOutwardActorInference"),
     .enableExperimentalFeature("AccessLevelOnImport"),
-    .enableExperimentalFeature("StrictConcurrency"),
+    .enableExperimentalFeature("GlobalConcurrency"),
 //    .enableExperimentalFeature("VariadicGenerics"),
 ]
 
@@ -22,6 +19,7 @@ let package = Package(
         .tvOS(.v13),
         .watchOS(.v6),
         .macCatalyst(.v13),
+        .visionOS(.v1),
     ],
     products: [
         .library(
@@ -33,7 +31,7 @@ let package = Package(
     ],
     dependencies: [
         .package(url: "https://github.com/swiftlang/swift-docc-plugin", from: "1.0.0"),
-        .package(url: "https://github.com/swiftlang/swift-syntax", from: "509.0.0"),
+        .package(url: "https://github.com/swiftlang/swift-syntax", "509.0.0"..<"601.0.0-prerelease"),
     ],
     targets: [
         // Targets are the basic building blocks of a package. A target can define a module or a test suite.

--- a/Sources/SemVer/Version+PrereleaseIdentifier.swift
+++ b/Sources/SemVer/Version+PrereleaseIdentifier.swift
@@ -1,5 +1,5 @@
 @_spi(SemVerValidation)
-package import SemVerParsing
+internal import SemVerParsing
 
 extension Version {
     /// Represents a prerelease identifier of a version.

--- a/Sources/SemVer/Version.swift
+++ b/Sources/SemVer/Version.swift
@@ -1,6 +1,6 @@
 import struct Foundation.CharacterSet
 @_spi(SemVerValidation)
-package import SemVerParsing
+internal import SemVerParsing
 
 extension CharacterSet {
     // Dance necessary because CharacterSet doesn't conform to Sendable in scf...

--- a/Sources/SemVerMacrosPlugin/VersionMacro.swift
+++ b/Sources/SemVerMacrosPlugin/VersionMacro.swift
@@ -1,7 +1,7 @@
 import SwiftSyntax
 import SwiftSyntaxMacros
 import SwiftDiagnostics
-package import SemVerParsing
+internal import SemVerParsing
 
 fileprivate extension DiagnosticMessage where Self == VersionMacro.DiagnosticMessage {
     static var notAStringLiteral: Self {

--- a/Tests/SemVerTests/VersionTests.swift
+++ b/Tests/SemVerTests/VersionTests.swift
@@ -21,7 +21,6 @@ final class VersionTests: XCTestCase {
     func testFullVersionStringWithPrereleaseDataWithoutMetadataData() {
         let version = Version(major: 1, minor: 2, patch: 3, prerelease: "beta-1")
         XCTAssertEqual(version.versionString(), "1.2.3-beta-1")
-        XCTAssertEqual(version.versionString(), "1.2.3-beta.1")
     }
 
     func testVersionStringExcludingPrerelease() {

--- a/Tests/SemVerTests/VersionTests.swift
+++ b/Tests/SemVerTests/VersionTests.swift
@@ -21,6 +21,7 @@ final class VersionTests: XCTestCase {
     func testFullVersionStringWithPrereleaseDataWithoutMetadataData() {
         let version = Version(major: 1, minor: 2, patch: 3, prerelease: "beta-1")
         XCTAssertEqual(version.versionString(), "1.2.3-beta-1")
+        XCTAssertEqual(version.versionString(), "1.2.3-beta.1")
     }
 
     func testVersionStringExcludingPrerelease() {


### PR DESCRIPTION
Added extra package.swift to support swift 6. Mainly conflicts due to swift-syntax versions I tried to avoid in a similar way as done in https://github.com/pointfreeco/swift-issue-reporting

Some additional minor cleanup

1. links to dependencies for apple related swift packages moved to swiftlang
2. fixed some warnings on imports 
3. removed features that are enabled in swift 6